### PR TITLE
Use `RandomBranchSelector` for `pr_calc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-2022", "macos-latest"]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: "Python ${{ matrix.python }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,19 +24,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 requires-python = ">=3.8,<3.13"
-dynamic = ["version"]
-dependencies = [
-    "graphix>=0.2.15",
-    "sympy>=1.9",
-]
-[project.optional-dependencies]
-dev = [
-    "black==24.4.0",
-    "isort==5.13.2",
-    "pytest",
-    "parameterized",
-    "tox",
-]
+dynamic = ["version", "dependencies", "optional-dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools.dynamic.optional-dependencies]
+dev = { file = ["requirements-dev.txt"] }
 
 [project.urls]
 Documentation = "https://graphix.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.14"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-graphix @ git+https://github.com/thierry-martinez/graphix@parameterized
+graphix @ git+https://github.com/thierry-martinez/graphix@branch_selector
 sympy>=1.9

--- a/tests/test_sympy_parameter.py
+++ b/tests/test_sympy_parameter.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from graphix import Circuit
+from graphix.branch_selector import RandomBranchSelector
 from numpy.random import Generator
 
 from graphix_symbolic import SympyParameter
@@ -34,18 +35,11 @@ def test_parameter_pattern_simulation(backend, fx_rng: Generator) -> None:
     circuit = Circuit(1)
     circuit.rz(0, alpha)
     pattern = circuit.transpile().pattern
-    # Both simulations (numeric and symbolic) will use the same
-    # seed for random number generation, to ensure that the
-    # explored branch is the same for the two simulations.
-    seed = fx_rng.integers(2**63)
-    result_subs_then_simulate = pattern.subs(alpha, 0.5).simulate_pattern(
-        backend, pr_calc=False, rng=np.random.default_rng(seed)
-    )
-    # Note: pr_calc=False is mandatory since we cannot compute
-    # probabilities on symbolic states; we explore one arbitrary
-    # branch.
+    result_subs_then_simulate = pattern.subs(alpha, 0.5).simulate_pattern(backend, rng=fx_rng)
+    # We cannot compute probabilities on symbolic states; we explore
+    # one arbitrary branch.
     result_simulate_then_subs = pattern.simulate_pattern(
-        backend, pr_calc=False, rng=np.random.default_rng(seed), symbolic=True
+        backend, branch_selector=RandomBranchSelector(pr_calc=False, rng=fx_rng), symbolic=True
     ).subs(alpha, 0.5)
     if backend == "statevector":
         assert np.allclose(result_subs_then_simulate.psi, result_simulate_then_subs.psi)

--- a/tests/test_sympy_parameter.py
+++ b/tests/test_sympy_parameter.py
@@ -39,7 +39,7 @@ def test_parameter_pattern_simulation(backend, fx_rng: Generator) -> None:
     # We cannot compute probabilities on symbolic states; we explore
     # one arbitrary branch.
     result_simulate_then_subs = pattern.simulate_pattern(
-        backend, branch_selector=RandomBranchSelector(pr_calc=False, rng=fx_rng), symbolic=True
+        backend, branch_selector=RandomBranchSelector(pr_calc=False), rng=fx_rng, symbolic=True
     ).subs(alpha, 0.5)
     if backend == "statevector":
         assert np.allclose(result_subs_then_simulate.psi, result_simulate_then_subs.psi)


### PR DESCRIPTION
This commit adapts the test for the introduction of branch selectors in Graphix, that removes the `pr_calc` argument from `simulate_pattern`.

We actually don't need to fix the same branch on the two simulations, since the pattern is deterministic.
